### PR TITLE
Host packages as pacman repository using GitHub Pages

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,10 @@ on:
     tags: '*'
   workflow_dispatch:
 
+permissions:
+  pages: write
+  id-token: write
+
 env:
   PKGDEST: "/tmp/linux-chimeraos"
   BUILDDIR: "/tmp/build"
@@ -63,6 +67,18 @@ jobs:
           path: |
             ${{ env.PKGDEST }}/*.pkg.tar.zst
           if-no-files-found: error
+      - name: Create repo archive
+        run: |
+          cd $PKGDEST
+          repo-add linux-chimeraos.db.tar.gz *.pkg.tar.zst
+          mv linux-chimeraos.db.tar.gz linux-chimeraos.db
+          mv linux-chimeraos.files.tar.gz linux-chimeraos.files
+          tar -cvf repo.tar ./*
+      - name: Upload repo artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: github-pages
+          path: ${{ env.PKGDEST }}/repo.tar
 
   make-release:
     runs-on: ubuntu-latest
@@ -84,3 +100,16 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             ${{ env.PKGDEST }}/*.pkg.tar.zst
+
+  make-repo:
+      needs: [build-kernel]
+      runs-on: ubuntu-latest
+      environment:
+        name: github-pages
+        url: ${{ steps.deployment.outputs.page_url }}
+      steps:
+        - name: Setup Pages
+          uses: actions/configure-pages@v5
+        - name: Deploy to GitHub Pages
+          id: deployment
+          uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -7,6 +7,22 @@ This repository will use a PKGBUILD to build ArchLinux packages and publish
 them as GitHub releases in binary package form. We currently do not provide a
 custom ArchLinux repository.
 
+## Pacman Repository
+
+The pacman repository created from this repo is published to GitHub Pages by the GitHub Action in this repo. The repository can be configured in `pacman` like this at the bottom of `/etc/pacman.conf`:
+
+```
+[linux-chimeraos]
+SigLevel = Optional TrustAll
+Server = https://chimeraos.github.io/linux-chimeraos/
+```
+
+Installing the packages from this repo can be done with:
+
+```shell
+pacman -Sy linux-chimeraos/linux-chimeraos linux-chimeraos/linux-chimeraos-headers
+```
+
 # Contributing
 
 Feel free to submit Pull Requests if a patch has merit over the current stable

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Server = https://chimeraos.github.io/linux-chimeraos/
 Installing the packages from this repo can be done with:
 
 ```shell
-pacman -Sy linux-chimeraos/linux-chimeraos linux-chimeraos/linux-chimeraos-headers
+pacman -Sy linux-chimeraos linux-chimeraos-headers
 ```
 
 # Contributing


### PR DESCRIPTION
This will make it so releases are also hosted as a pacman repository using GitHub Pages.

I did one build using it. To test this, add the following to your `/etc/pacman.conf`:
```
[linux-chimeraos]
SigLevel = Optional TrustAll
Server = https://sharkwouter.github.io/linux-chimeraos/
```

Then you can download the packages using the following command:
```shell
pacman -Sy linux-chimeraos linux-chimeraos-headers
```

I've added instructions specific for the ChimeraOS group to the README.

Before merging this PR, make sure to set the GitHub Pages source to GitHub Actions in the settings of the GitHub repo like in the image below:
![image](https://github.com/user-attachments/assets/202eaa34-b82b-45ce-bfa1-20e9509fbcc7)

It would be possible to add signing later, but since right now packages are just downloaded using wget, I don't think that will be needed. Especially since we're using https here, so a man in the middle attack would be very hard to do anyway.